### PR TITLE
Various refactorings

### DIFF
--- a/src/FSharp.CosmosDb.Analyzer/CosmosCodeAnalysis.fs
+++ b/src/FSharp.CosmosDb.Analyzer/CosmosCodeAnalysis.fs
@@ -50,12 +50,7 @@ module CosmosCodeAnalysis =
             | _ ->
                 None)
         |> Option.bind(fun args ->
-            let fullName =
-                args.Ids
-                |> List.map (fun id -> id.idText)
-                |> String.concat "."
-
-            match fullName with
+            match dotConcat args.Ids with
             | "Cosmos.query" ->
                 let names =
                     args.TypeNames

--- a/src/FSharp.CosmosDb.Analyzer/CosmosCodeAnalysis.fs
+++ b/src/FSharp.CosmosDb.Analyzer/CosmosCodeAnalysis.fs
@@ -5,48 +5,27 @@ open FSharp.Compiler.Range
 open FSharp.Compiler.SyntaxTree
 
 module CosmosCodeAnalysis =
-    let (|Apply|_|) =
-        function
-        | SynExpr.TypeApp (funcExpr, lessRange, typeNames, commasRange, greaterRange, typeArgsRange, range) ->
-            match funcExpr with
-            | SynExpr.Ident ident -> Some(ident.idText, funcExpr, funcExpr.Range, range)
-            | SynExpr.LongIdent (isOptional, longDotId, altName, identRange) ->
-                match longDotId with
-                | LongIdentWithDots (listOfIds, ranges) ->
-                    let fullName =
-                        listOfIds
-                        |> List.map (fun id -> id.idText)
-                        |> String.concat "."
-
-                    Some(fullName, funcExpr, funcExpr.Range, range)
-            | _ -> None
-        | SynExpr.App (atomicFlag, isInfix, funcExpr, argExpr, applicationRange) ->
-            match funcExpr with
-            | SynExpr.Ident ident -> Some(ident.idText, argExpr, funcExpr.Range, applicationRange)
-            | SynExpr.LongIdent (isOptional, longDotId, altName, identRange) ->
-                match longDotId with
-                | LongIdentWithDots (listOfIds, ranges) ->
-                    let fullName =
-                        listOfIds
-                        |> List.map (fun id -> id.idText)
-                        |> String.concat "."
-
-                    Some(fullName, argExpr, funcExpr.Range, applicationRange)
-            | _ -> None
+    let dotConcat = List.map(fun (id:Ident) -> id.idText) >> String.concat "."
+    let (|Apply|_|) synExpr =
+        match synExpr with
+        | SynExpr.TypeApp (funcExpr, _, _, _, _, _, range) -> Some (funcExpr, funcExpr, range)
+        | SynExpr.App (_, _, funcExpr, argExpr, range) -> Some (funcExpr, argExpr, range)
         | _ -> None
+        |> Option.bind(fun (funcExpr, argExpr, range) ->
+            match funcExpr with
+            | SynExpr.Ident ident ->
+                Some(ident.idText, argExpr, funcExpr.Range, range)
+            | SynExpr.LongIdent (_, LongIdentWithDots (listOfIds, _), _, _) ->
+                Some(dotConcat listOfIds, argExpr, funcExpr.Range, range)
+            | _ ->
+                None)
 
     let (|LongIdent|_|) =
         function
-        | SynExpr.LongIdent (isOptional, longDotId, altName, identRange) ->
-            match longDotId with
-            | LongIdentWithDots (listOfIds, ranges) ->
-                let fullName =
-                    listOfIds
-                    |> List.map (fun id -> id.idText)
-                    |> String.concat "."
-
-                Some(fullName, range)
-        | _ -> None
+        | SynExpr.LongIdent (isOptional, LongIdentWithDots (listOfIds, ranges), altName, identRange) ->
+            Some(dotConcat listOfIds, range)
+        | _ ->
+            None
 
     let (|Query|_|) =
         function
@@ -58,44 +37,38 @@ module CosmosCodeAnalysis =
         | Apply ("Cosmos.query", SynExpr.Ident (identifier), funcRange, appRange) -> Some(identifier.idText, funcRange)
         | _ -> None
 
-    let (|TypedQuery|_|) =
-        function
-        | SynExpr.App (exprAtomic,
-                       isInfix,
-                       (SynExpr.TypeApp (funcExpr, lessRange, typeNames, commasRange, greaterRange, typeArgsRange, typeAppRange)),
-                       SynExpr.Const (SynConst.String (query, queryRange), constRange),
-                       appRange) ->
-            match funcExpr with
-            | SynExpr.LongIdent (isOptional, longDotId, altName, identRange) ->
-                match longDotId with
-                | LongIdentWithDots (listOfIds, ranges) ->
-                    let fullName =
-                        listOfIds
-                        |> List.map (fun id -> id.idText)
-                        |> String.concat "."
+    let (|TypedQuery|_|) synExpr =
+        match synExpr with
+        | SynExpr.App (_, _, (SynExpr.TypeApp (funcExpr, _, typeNames, _, _, _, typeAppRange)), SynExpr.Const (SynConst.String (query, _), _), _) ->
+            Some {| FuncExpr = funcExpr; TypeNames = typeNames; Range = typeAppRange; Query = query |}
+        | _ ->
+            None
+        |> Option.bind(fun args ->
+            match args.FuncExpr with
+            | SynExpr.LongIdent (_, LongIdentWithDots (listOfIds, _), _, _) ->
+                Some {| args with Ids = listOfIds |}
+            | _ ->
+                None)
+        |> Option.bind(fun args ->
+            let fullName =
+                args.Ids
+                |> List.map (fun id -> id.idText)
+                |> String.concat "."
 
-                    match fullName with
-                    | "Cosmos.query" ->
-                        let names =
-                            typeNames
-                            |> List.filter (fun typeName ->
-                                match typeName with
-                                | SynType.LongIdent (_) -> true
-                                | _ -> false)
-                            |> List.map (fun typeName ->
-                                match typeName with
-                                | SynType.LongIdent (dots) ->
-                                    match dots with
-                                    | LongIdentWithDots (listOfIds, _) ->
-                                        listOfIds
-                                        |> List.map (fun id -> id.idText)
-                                        |> String.concat "."
-                                | _ -> "")
+            match fullName with
+            | "Cosmos.query" ->
+                let names =
+                    args.TypeNames
+                    |> List.choose (fun typeName ->
+                        match typeName with
+                        | SynType.LongIdent (LongIdentWithDots (listOfIds, _)) ->
+                            dotConcat listOfIds |> Some
+                        | _ ->
+                            None)
 
-                        Some(names, query, typeAppRange)
-                    | _ -> None
-            | _ -> None
-        | _ -> None
+                Some(names, args.Query, args.Range)
+            | _ ->
+                None)
 
     let (|Database|_|) =
         function


### PR DESCRIPTION
I've made a few refactorings which you might find useful:

1. Made a simple `dotConcat` function for the repeated concat of strings to dots. This could be taken further as an active pattern, possibly.
1. Where there was a "single case" match e.g. `LongIdentWithDots`, I've moved that "inline" to remove unnecessary horizontal nesting.
1. `Apply` has been compressed - both `TypeApp` and `App` branches (appear?) to do the same thing; the only difference is that `TypeApp` uses the `funcExpr` where the `App` uses `argExpr`. Both are the same type so we can merge both branches into one.
1. There were a couple of cases of filter + map - I've now migrated this to use `choose` which is normally what filter + map represents semantically.
1. `TypedQuery` has been refactored using the same techniques as above. I used an anonymous record to create a "payload" of the relevant args and pipe them through `Option.bind`. Doing this keeps each transformation separate.