### PR TITLE
CI runs on windows-latest instead of linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This tries to solve CI stuck issue.
This seems to work so far, not sure if it is going to work every time.