### PR TITLE
Add deleteContainer operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ let main argv =
     } |> Async.RunSynchronously
 ```
 
-### Delete
+### DeleteItem
 
-```fsharp
+```f#
 open FSharp.CosmosDb
 
 let connStr = "..."
@@ -116,6 +116,19 @@ let updateUser id partitionKey =
     |> Cosmos.execAsync
 ```
 
+### DeleteContainer
+```f#
+open FSharp.CosmosDb
+
+let connStr = "..."
+
+connStr
+|> Cosmos.container "ContainerName"
+|> Cosmos.deleteContainer
+|> Cosmos.execAsync
+|> Async.Ignore
+```
+    
 # FSharp.CosmosDb.Analyzer 💡
 
 [![NuGet Badge - FSharp.CosmosDb](https://buildstats.info/nuget/FSharp.CosmosDb)](https://www.nuget.org/packages/FSharp.CosmosDb)

--- a/samples/FSharp.CosmosDb.Samples/Program.fs
+++ b/samples/FSharp.CosmosDb.Samples/Program.fs
@@ -50,7 +50,7 @@ let updateFamily conn id pk =
 
 let deleteFamily conn id pk =
     conn
-    |> Cosmos.delete<Family> id pk
+    |> Cosmos.deleteItem<Family> id pk
     |> Cosmos.execAsync
 
 [<EntryPoint>]
@@ -131,6 +131,13 @@ let main argv =
             |> AsyncSeq.map (fun f -> { f with LastName = "Powellz" })
             |> AsyncSeq.map (fun f -> conn |> Cosmos.replace f |> Cosmos.execAsync)
             |> AsyncSeq.iter (fun f -> printfn "Replaced: %A" f)
+            
+        do!
+            conn
+            |> Cosmos.container "Family"
+            |> Cosmos.deleteContainer
+            |> Cosmos.execAsync
+            |> Async.Ignore
 
         return 0 // return an integer exit code
     }

--- a/samples/FSharp.CosmosDb.Samples/Program.fs
+++ b/samples/FSharp.CosmosDb.Samples/Program.fs
@@ -138,6 +138,13 @@ let main argv =
             |> Cosmos.deleteContainer
             |> Cosmos.execAsync
             |> Async.Ignore
+            
+        do!
+            conn
+            |> Cosmos.container "Family"
+            |> Cosmos.deleteContainerIfExists
+            |> Cosmos.execAsync
+            |> Async.Ignore
 
         return 0 // return an integer exit code
     }

--- a/src/FSharp.CosmosDb/Cosmos.fs
+++ b/src/FSharp.CosmosDb/Cosmos.fs
@@ -54,6 +54,10 @@ module Cosmos =
 
     let parameters arr op =
         { op with QueryOp.Parameters = op.Parameters @ arr }
+        
+    // --- DATABASE EXISTS --- //
+    let databaseExists<'T> op =
+        { CheckIfDatabaseExistsOp.Connection = op }
 
     // --- INSERT --- //
 
@@ -85,11 +89,24 @@ module Cosmos =
         { DeleteItemOp.Connection = op
           Id = id
           PartitionKey = partitionKey }
+        
+    // --- GET CONTAINER PROPERTIES --- //
+    let getContainerProperties op =
+        { GetContainerPropertiesOp.Connection = op }
+        
+    // --- CONTAINER EXISTS --- //
+    let containerExists op =
+        { CheckIfContainerExistsOp.Connection = op }
             
     // --- DELETE CONTAINER --- //
 
     let deleteContainer<'T> op : DeleteContainerOp<'T> =
         { DeleteContainerOp.Connection = op }
+
+    // --- DELETE CONTAINER IF EXISTS --- //
+
+    let deleteContainerIfExists op : DeleteContainerIfExistsOp =
+        { DeleteContainerIfExistsOp.Connection = op }
 
     // --- READ --- //
 
@@ -220,10 +237,14 @@ module Cosmos =
 type Cosmos =
     static member private getClient (connInfo: ConnectionOperation) = connInfo.GetClient()
     static member execAsync (op: QueryOp<'T>) = OperationHandling.execQuery Cosmos.getClient op
+    static member execAsync op = OperationHandling.execCheckIfDatabaseExists Cosmos.getClient op
     static member execAsync op = OperationHandling.execInsert Cosmos.getClient op
     static member execAsync op = OperationHandling.execUpdate Cosmos.getClient op
     static member execAsync op = OperationHandling.execDeleteItem Cosmos.getClient op
+    static member execAsync op = OperationHandling.execGetContainerProperties Cosmos.getClient op
+    static member execAsync op = OperationHandling.execCheckIfContainerExists Cosmos.getClient op
     static member execAsync op = OperationHandling.execDeleteContainer Cosmos.getClient op
+    static member execAsync op = OperationHandling.execDeleteContainerIfExists Cosmos.getClient op
     static member execAsync op = OperationHandling.execUpsert Cosmos.getClient op
     static member execAsync op = OperationHandling.execRead Cosmos.getClient op
     static member execAsync op = OperationHandling.execReplace Cosmos.getClient op

--- a/src/FSharp.CosmosDb/Cosmos.fs
+++ b/src/FSharp.CosmosDb/Cosmos.fs
@@ -47,65 +47,61 @@ module Cosmos =
           Query = None
           Parameters = [] }
 
-    let query<'T> query op : ContainerOperation<'T> =
-        Query
-            { defaultQueryOp () with
-                  Query = Some query
-                  Connection = op }
+    let query<'T> query op : QueryOp<'T> =
+        { defaultQueryOp () with
+              Query = Some query
+              Connection = op }
 
     let parameters arr op =
-        match op with
-        | Query q ->
-            Query
-                { q with
-                      Parameters = q.Parameters @ arr }
-        | _ -> failwith "Only the Query discriminated union supports parameters"
+        { op with QueryOp.Parameters = op.Parameters @ arr }
 
     // --- INSERT --- //
 
     let insertMany<'T> (values: 'T list) op =
-        Insert { Connection = op; Values = values }
+        { InsertOp.Connection = op; Values = values }
 
     let insert<'T> (value: 'T) op =
-        Insert { Connection = op; Values = [ value ] }
+        { InsertOp.Connection = op; Values = [ value ] }
 
     // --- INSERT --- //
 
     let upsertMany<'T> (values: 'T list) op =
-        Upsert { Connection = op; Values = values }
+        { UpsertOp.Connection = op; Values = values }
 
     let upsert<'T> (value: 'T) op =
-        Upsert { Connection = op; Values = [ value ] }
+        { UpsertOp.Connection = op; Values = [ value ] }
 
     // --- UPDATE --- //
 
     let update<'T> id partitionKey (updater: 'T -> 'T) op =
-        Update
-            { Connection = op
-              Id = id
-              PartitionKey = partitionKey
-              Updater = updater }
+        { UpdateOp.Connection = op
+          Id = id
+          PartitionKey = partitionKey
+          Updater = updater }
 
-    // --- DELETE --- //
+    // --- DELETE ITEM --- //
 
-    let delete<'T> id partitionKey op =
-        Delete
-            { Connection = op
-              Id = id
-              PartitionKey = partitionKey }
+    let deleteItem<'T> id partitionKey op =
+        { DeleteItemOp.Connection = op
+          Id = id
+          PartitionKey = partitionKey }
+            
+    // --- DELETE CONTAINER --- //
+
+    let deleteContainer<'T> op : DeleteContainerOp<'T> =
+        { DeleteContainerOp.Connection = op }
 
     // --- READ --- //
 
     let read id partitionKey op =
-        Read
-            { Connection = op
-              Id = id
-              PartitionKey = partitionKey }
+        { ReadOp.Connection = op
+          Id = id
+          PartitionKey = partitionKey }
 
     // --- REPLACE --- //
 
     let replace<'T> (item: 'T) op =
-        Replace { Connection = op; Item = item }
+        { ReplaceOp.Connection = op; Item = item }
 
     // --- Execute --- //
 
@@ -113,23 +109,10 @@ module Cosmos =
 
     let dispose (connInfo: ConnectionOperation) = (connInfo :> IDisposable).Dispose()
 
-    let execAsync<'T> (op: ContainerOperation<'T>) =
-        match op with
-        | Query op -> OperationHandling.execQuery getClient op
-        | Insert op -> OperationHandling.execInsert getClient op
-        | Update op -> OperationHandling.execUpdate getClient op
-        | Delete op -> OperationHandling.execDelete getClient op
-        | Upsert op -> OperationHandling.execUpsert getClient op
-        | Read op -> OperationHandling.execRead getClient op
-        | Replace op -> OperationHandling.execReplace getClient op
-
-    let execBatchAsync<'T> batchSize (op: ContainerOperation<'T>) =
-        match op with
-        | Query op ->
-            let queryOps = QueryRequestOptions()
-            queryOps.MaxItemCount <- batchSize
-            OperationHandling.execQueryBatch getClient op queryOps
-        | _ -> failwith "Batch return operation only supported with query operations, use `execAsync` instead."
+    let execBatchAsync<'T> batchSize op =
+        let queryOps = QueryRequestOptions()
+        queryOps.MaxItemCount <- batchSize
+        OperationHandling.execQueryBatch getClient op queryOps
 
     // --- Access Cosmos APIs directly --- //
 
@@ -233,3 +216,14 @@ module Cosmos =
                 processor.Build()
             | None ->
                 failwith "Unable to connect the change feed. Ensure the container and lease container info is all set"
+                
+type Cosmos =
+    static member private getClient (connInfo: ConnectionOperation) = connInfo.GetClient()
+    static member execAsync (op: QueryOp<'T>) = OperationHandling.execQuery Cosmos.getClient op
+    static member execAsync op = OperationHandling.execInsert Cosmos.getClient op
+    static member execAsync op = OperationHandling.execUpdate Cosmos.getClient op
+    static member execAsync op = OperationHandling.execDeleteItem Cosmos.getClient op
+    static member execAsync op = OperationHandling.execDeleteContainer Cosmos.getClient op
+    static member execAsync op = OperationHandling.execUpsert Cosmos.getClient op
+    static member execAsync op = OperationHandling.execRead Cosmos.getClient op
+    static member execAsync op = OperationHandling.execReplace Cosmos.getClient op

--- a/src/FSharp.CosmosDb/Types.fs
+++ b/src/FSharp.CosmosDb/Types.fs
@@ -1,5 +1,6 @@
 namespace FSharp.CosmosDb
 
+open FSharp.CosmosDb
 open Microsoft.Azure.Cosmos
 open System.Threading
 open System.Threading.Tasks
@@ -100,10 +101,13 @@ type UpdateOp<'T> =
       PartitionKey: string
       Updater: 'T -> 'T }
 
-type DeleteOp<'T> =
+type DeleteItemOp<'T> =
     { Connection: ConnectionOperation
       Id: string
       PartitionKey: string }
+    
+type DeleteContainerOp<'T> =
+    { Connection: ConnectionOperation }
 
 type ReadOp<'T> =
     { Connection: ConnectionOperation
@@ -113,15 +117,6 @@ type ReadOp<'T> =
 type ReplaceOp<'T> =
     { Connection: ConnectionOperation
       Item: 'T }
-
-type ContainerOperation<'T> =
-    | Query of QueryOp<'T>
-    | Insert of InsertOp<'T>
-    | Update of UpdateOp<'T>
-    | Delete of DeleteOp<'T>
-    | Upsert of UpsertOp<'T>
-    | Read of ReadOp<'T>
-    | Replace of ReplaceOp<'T>
 
 type ChangeFeedOptions<'T> =
     { Connection: ConnectionOperation

--- a/src/FSharp.CosmosDb/Types.fs
+++ b/src/FSharp.CosmosDb/Types.fs
@@ -87,6 +87,9 @@ type QueryOp<'T> =
       Query: string option
       Parameters: (string * obj) list }
 
+type CheckIfDatabaseExistsOp =
+    { Connection: ConnectionOperation }
+
 type InsertOp<'T> =
     { Connection: ConnectionOperation
       Values: 'T list }
@@ -106,9 +109,18 @@ type DeleteItemOp<'T> =
       Id: string
       PartitionKey: string }
     
+type GetContainerPropertiesOp = 
+    { Connection: ConnectionOperation }
+    
+type CheckIfContainerExistsOp =
+    { Connection: ConnectionOperation }
+    
 type DeleteContainerOp<'T> =
     { Connection: ConnectionOperation }
 
+type DeleteContainerIfExistsOp =
+    { Connection: ConnectionOperation }
+    
 type ReadOp<'T> =
     { Connection: ConnectionOperation
       Id: string


### PR DESCRIPTION
This a proposition for adding a new operation : **deleteContainer**

This includes: 

- A usage sample in README.md and Samples project
- A breaking change in the previously named **delete** operation which is renamed to **deleteItem**
- Replacement of **let execAsync<'T> (op: ContainerOperation<'T>) = ...** with method overloading (see static type Cosmos).
   This is explained by the fact that deleteContainer does not return an AsyncSeq<'t> like all the branches of pattern matches in **let execAsync<'T> (op: ContainerOperation<'T>) = ...**