### PR TITLE
Linq Query Operation

### DIFF
--- a/samples/FSharp.CosmosDb.Samples/Program.fs
+++ b/samples/FSharp.CosmosDb.Samples/Program.fs
@@ -38,6 +38,16 @@ let getFamilies conn =
     |> Cosmos.parameters [ "@lastName", box "Powell" ]
     |> Cosmos.execAsync
 
+let getFamilyLastNames conn =
+    conn
+    |> Cosmos.linq<Family, string> (fun families ->
+        cosmosQuery {
+            for family in families do
+            where (family.LastName = "Powell")
+            select family.LastName
+        })
+    |> Cosmos.execAsync
+
 let updateFamily conn id pk =
     conn
     |> Cosmos.update<Family>
@@ -111,6 +121,12 @@ let main argv =
         do!
             families
             |> AsyncSeq.iter (fun f -> printfn "Got: %A" f)
+
+        let lastNames = getFamilyLastNames conn
+
+        do!
+            lastNames
+            |> AsyncSeq.iter (printfn "Got: %s") 
 
         let updatePowell = updateFamily conn "Powell.1" "Powell"
 

--- a/src/FSharp.CosmosDb/FSharp.CosmosDb.fsproj
+++ b/src/FSharp.CosmosDb/FSharp.CosmosDb.fsproj
@@ -10,6 +10,7 @@
     <Compile Include="PartitionKeyAttribute.fs" />
     <Compile Include="Types.fs" />
     <Compile Include="OperationHandling.fs" />
+    <Compile Include="QueryBuilder.fs" />
     <Compile Include="Cosmos.fs" />
   </ItemGroup>
   <Import Project="..\..\.paket\Paket.Restore.targets" />

--- a/src/FSharp.CosmosDb/QueryBuilder.fs
+++ b/src/FSharp.CosmosDb/QueryBuilder.fs
@@ -1,0 +1,48 @@
+namespace FSharp.CosmosDb
+
+open System
+open System.Linq
+open FSharp.Linq
+open FSharp.Quotations
+open FSharp.Quotations.DerivedPatterns
+open FSharp.Quotations.ExprShape
+
+type CosmosQueryBuilder() =
+    inherit QueryBuilder()
+
+    static let rec replace =
+        // Replace F# functions with BCL equivalents.
+        function
+        | SpecificCall <@@ abs @@> (_, [ typ ], args) ->
+            let e = replace args.Head
+            if typ = typeof<int8> then
+                <@@ (Math.Abs : int8 -> int8) %%e @@>
+            elif typ = typeof<int16> then
+                <@@ (Math.Abs : int16 -> int16) %%e @@>
+            elif typ = typeof<int32> then
+                <@@ (Math.Abs : int32 -> int32) %%e @@>
+            elif typ = typeof<int64> then
+                <@@ (Math.Abs : int64 -> int64) %%e @@>
+            elif typ = typeof<float32> then
+                <@@ (Math.Abs : float32 -> float32) %%e @@>
+            elif typ = typeof<float> then
+                <@@ (Math.Abs : float -> float) %%e @@>
+            elif typ = typeof<decimal> then
+                <@@ (Math.Abs : decimal -> decimal) %%e @@>
+            else 
+                failwith $"Invalid argument type for translation of 'abs': {typ.FullName}"
+        | SpecificCall <@@ acos @@> (_, [ _ ], args) ->
+            let e = replace args.Head
+            <@@ (Math.Acos : float -> float) %%e @@>
+        | ShapeVar v -> Expr.Var v
+        | ShapeLambda(v, expr) -> Expr.Lambda(v, replace expr)
+        | ShapeCombination(o, args) -> 
+            RebuildShapeCombination(o, List.map replace args)
+
+    member _.Run(e: Expr<QuerySource<'a, IQueryable>>) =
+        let r = Expr.Cast<QuerySource<'a, IQueryable>>(replace e)
+        base.Run r
+
+[<AutoOpen>]
+module QueryBuilder =
+    let cosmosQuery = CosmosQueryBuilder()

--- a/src/FSharp.CosmosDb/Types.fs
+++ b/src/FSharp.CosmosDb/Types.fs
@@ -6,6 +6,7 @@ open System.Threading.Tasks
 open System.Collections.Concurrent
 open System
 open System.Collections.Generic
+open System.Linq
 
 module internal Caching =
     let private clientCache =
@@ -86,6 +87,10 @@ type QueryOp<'T> =
       Query: string option
       Parameters: (string * obj) list }
 
+type LinqOp<'T> =
+    { Connection: ConnectionOperation
+      Query: Container -> IQueryable<'T> }
+
 type InsertOp<'T> =
     { Connection: ConnectionOperation
       Values: 'T list }
@@ -116,6 +121,7 @@ type ReplaceOp<'T> =
 
 type ContainerOperation<'T> =
     | Query of QueryOp<'T>
+    | Linq of LinqOp<'T>
     | Insert of InsertOp<'T>
     | Update of UpdateOp<'T>
     | Delete of DeleteOp<'T>


### PR DESCRIPTION
#65

Adds an operation for linq support using an extended version of the FSharp.Linq.QueryBuilder `query` computational expression called `cosmosQuery`. 

`CosmosQueryBuilder` extends the standard query syntax by mapping F# functions to BCL equivalents (eg: `abs` -> `System.Math.Abs`) to allow for utilization in cosmos queries.
https://docs.microsoft.com/en-us/azure/cosmos-db/sql/sql-query-linq-to-sql

Adds the operation to the sample program:
```fsharp
|> Cosmos.linq<Family, string> (fun families ->
    cosmosQuery {
        for family in families do
        where (family.LastName = "Powell")
        select family.LastName
    })
|> Cosmos.execAsync
```

