### PR TITLE
[new feature] Connection with Identity - Issue #73

### DIFF
--- a/paket.dependencies
+++ b/paket.dependencies
@@ -19,6 +19,7 @@ nuget Microsoft.Build
 nuget Microsoft.Build.Framework
 nuget Microsoft.Build.Utilities.Core
 nuget FSharp.SystemTextJson
+nuget Azure.Identity
 
 // [ FAKE GROUP ]
 group Build

--- a/paket.lock
+++ b/paket.lock
@@ -1,16 +1,25 @@
 STORAGE: NONE
 NUGET
   remote: https://api.nuget.org/v3/index.json
-    Azure.Core (1.25) - restriction: >= netstandard2.0
+    Azure.Core (1.36) - restriction: >= netstandard2.0
       Microsoft.Bcl.AsyncInterfaces (>= 1.1.1) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Diagnostics.DiagnosticSource (>= 4.6) - restriction: || (>= net461) (>= netstandard2.0)
+      System.Diagnostics.DiagnosticSource (>= 4.6) - restriction: && (< net5.0) (>= netcoreapp2.1)
+      System.Diagnostics.DiagnosticSource (>= 6.0.1) - restriction: || (>= net461) (>= net5.0) (&& (< netcoreapp2.1) (>= netstandard2.0))
       System.Memory.Data (>= 1.0.2) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Net.Http (>= 4.3.4) - restriction: >= net461
+      System.Net.Http (>= 4.3.4) - restriction: && (>= net461) (< net472)
       System.Numerics.Vectors (>= 4.5) - restriction: || (>= net461) (>= netstandard2.0)
-      System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: >= net461
+      System.Runtime.InteropServices.RuntimeInformation (>= 4.3) - restriction: && (>= net461) (< net472)
       System.Text.Encodings.Web (>= 4.7.2) - restriction: || (>= net461) (>= netstandard2.0)
       System.Text.Json (>= 4.7.2) - restriction: || (>= net461) (>= netstandard2.0)
       System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: || (>= net461) (>= netstandard2.0)
+    Azure.Identity (1.10.4)
+      Azure.Core (>= 1.36) - restriction: >= netstandard2.0
+      Microsoft.Identity.Client (>= 4.56) - restriction: >= netstandard2.0
+      Microsoft.Identity.Client.Extensions.Msal (>= 4.56) - restriction: >= netstandard2.0
+      System.Memory (>= 4.5.4) - restriction: >= netstandard2.0
+      System.Security.Cryptography.ProtectedData (>= 4.7) - restriction: >= netstandard2.0
+      System.Text.Json (>= 4.7.2) - restriction: >= netstandard2.0
+      System.Threading.Tasks.Extensions (>= 4.5.4) - restriction: >= netstandard2.0
     Expecto (9.0.4)
       FSharp.Core (>= 4.6) - restriction: || (>= net461) (>= netstandard2.0)
       Mono.Cecil (>= 0.11.3) - restriction: || (>= net461) (>= netstandard2.0)
@@ -113,6 +122,7 @@ NUGET
       System.Security.Permissions (>= 4.7) - restriction: && (< net472) (< net6.0) (>= netstandard2.0)
       System.Text.Encoding.CodePages (>= 4.0.1) - restriction: && (< net472) (< net6.0) (>= netstandard2.0)
     Microsoft.CodeCoverage (17.2) - restriction: || (>= net45) (>= netcoreapp2.1)
+    Microsoft.CSharp (4.7) - restriction: && (< net6.0) (>= xamarinios)
     Microsoft.DotNet.PlatformAbstractions (3.1.6) - restriction: >= net5.0
     Microsoft.Extensions.Configuration (6.0.1)
       Microsoft.Extensions.Configuration.Abstractions (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
@@ -153,6 +163,26 @@ NUGET
     Microsoft.Extensions.Primitives (6.0) - restriction: || (>= net461) (>= netstandard2.0)
       System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< netcoreapp3.1) (>= netstandard2.0))
       System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    Microsoft.Identity.Client (4.58) - restriction: >= netstandard2.0
+      Microsoft.CSharp (>= 4.5) - restriction: || (&& (< net45) (< netstandard2.0)) (&& (< net6.0) (>= xamarinios))
+      Microsoft.Identity.Client.NativeInterop (>= 0.13.14) - restriction: >= net6.0-windows7.0
+      Microsoft.IdentityModel.Abstractions (>= 6.22) - restriction: || (&& (>= monoandroid10.0) (< net6.0)) (&& (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)) (&& (< monoandroid9.0) (< net45) (< net6.0) (>= netstandard2.0) (< xamarinios)) (&& (< monoandroid9.0) (>= net6.0) (< xamarinios)) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netstandard2.0)) (>= net462) (&& (< net6.0) (>= xamarinios)) (>= net6.0-android) (>= net6.0-ios) (>= net6.0-windows7.0)
+      Microsoft.Web.WebView2 (>= 1.0.864.35) - restriction: >= net6.0-windows7.0
+      System.ComponentModel.TypeConverter (>= 4.3) - restriction: && (< net6.0) (>= xamarinios)
+      System.Diagnostics.DiagnosticSource (>= 7.0.2) - restriction: || (&& (< monoandroid9.0) (< net45) (< net6.0) (>= netstandard2.0) (< xamarinios)) (&& (< monoandroid9.0) (>= net6.0) (< xamarinios)) (>= net462) (>= net6.0-windows7.0)
+      System.Runtime.InteropServices.NFloat.Internal (>= 6.0.1) - restriction: >= net6.0-ios
+      System.Runtime.Serialization.Formatters (>= 4.3) - restriction: || (&& (< net45) (< netstandard2.0)) (&& (< net6.0) (>= xamarinios))
+      System.Runtime.Serialization.Primitives (>= 4.3) - restriction: || (&& (< net45) (< netstandard2.0)) (&& (< net6.0) (>= xamarinios))
+      System.Security.SecureString (>= 4.3) - restriction: || (&& (>= monoandroid10.0) (< net6.0)) (&& (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)) (&& (< net45) (< netstandard2.0)) (&& (< net6.0) (>= xamarinios)) (>= net6.0-android) (>= net6.0-ios)
+      System.Xml.XmlDocument (>= 4.3) - restriction: && (< net6.0) (>= xamarinios)
+      Xamarin.Android.Support.CustomTabs (>= 28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.AndroidX.Browser (>= 1.0) - restriction: && (>= monoandroid10.0) (< net6.0)
+    Microsoft.Identity.Client.Extensions.Msal (4.58) - restriction: >= netstandard2.0
+      Microsoft.Identity.Client (>= 4.58) - restriction: >= netstandard2.0
+      System.IO.FileSystem.AccessControl (>= 5.0) - restriction: >= netstandard2.0
+      System.Security.Cryptography.ProtectedData (>= 4.5) - restriction: >= netstandard2.0
+    Microsoft.Identity.Client.NativeInterop (0.13.14) - restriction: >= net6.0-windows7.0
+    Microsoft.IdentityModel.Abstractions (7.0.3) - restriction: || (&& (>= monoandroid10.0) (< net6.0)) (&& (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)) (&& (< monoandroid9.0) (< net45) (< net6.0) (>= netstandard2.0) (< xamarinios)) (&& (< monoandroid9.0) (>= net6.0) (< xamarinios)) (&& (>= net462) (>= netstandard2.0)) (&& (< net6.0) (>= xamarinios)) (>= net6.0-android) (>= net6.0-ios) (>= net6.0-windows7.0)
     Microsoft.IO.Redist (6.0) - restriction: >= net472
       System.Buffers (>= 4.5.1) - restriction: >= net472
       System.Memory (>= 4.5.4) - restriction: >= net472
@@ -205,6 +235,7 @@ NUGET
     Microsoft.TestPlatform.TestHost (17.2) - restriction: >= netcoreapp2.1
       Microsoft.TestPlatform.ObjectModel (>= 17.2) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
       Newtonsoft.Json (>= 9.0.1) - restriction: || (>= netcoreapp1.0) (>= uap10.0)
+    Microsoft.Web.WebView2 (1.0.2151.40) - restriction: >= net6.0-windows7.0
     Microsoft.Win32.Primitives (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.NETCore.Targets (>= 1.1) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -331,7 +362,7 @@ NUGET
       System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
       System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
     System.ComponentModel.Primitives (4.3) - restriction: >= uap10.0
-    System.ComponentModel.TypeConverter (4.3) - restriction: >= uap10.0
+    System.ComponentModel.TypeConverter (4.3) - restriction: || (&& (< net6.0) (>= xamarinios)) (>= uap10.0)
       System.ComponentModel.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.5) (< win8)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= net45) (< netstandard1.5)) (>= net462) (&& (< netstandard1.0) (>= win8)) (>= wp8) (>= wpa81)
     System.Configuration.ConfigurationManager (6.0) - restriction: >= netstandard2.0
       System.Security.Cryptography.ProtectedData (>= 6.0) - restriction: || (&& (< net461) (>= netstandard2.0)) (>= net6.0)
@@ -346,9 +377,9 @@ NUGET
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Diagnostics.DiagnosticSource (6.0) - restriction: >= netstandard2.0
-      System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< net5.0) (>= netstandard2.0))
-      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
+    System.Diagnostics.DiagnosticSource (8.0) - restriction: || (&& (< monoandroid9.0) (>= net6.0) (< xamarinios)) (>= netstandard2.0)
+      System.Memory (>= 4.5.5) - restriction: || (>= net462) (&& (< net6.0) (>= netstandard2.0))
+      System.Runtime.CompilerServices.Unsafe (>= 6.0) - restriction: || (>= net462) (&& (>= net6.0) (< net7.0)) (&& (< net6.0) (>= netstandard2.0))
     System.Diagnostics.Process (4.3) - restriction: >= netstandard2.0
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       Microsoft.Win32.Primitives (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.4) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -451,6 +482,11 @@ NUGET
       System.Runtime.Handles (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
+    System.IO.FileSystem.AccessControl (5.0) - restriction: >= netstandard2.0
+      System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (>= monotouch) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Memory (>= 4.5.4) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= uap10.1)
+      System.Security.AccessControl (>= 5.0) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0)) (>= monotouch) (&& (>= net46) (< netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
+      System.Security.Principal.Windows (>= 5.0) - restriction: || (&& (>= monoandroid) (< netstandard1.3)) (&& (< monoandroid) (< net46) (>= netstandard1.3) (< netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0)) (>= monotouch) (&& (>= net46) (< netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (>= netcoreapp2.1) (>= uap10.1) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
     System.IO.FileSystem.Primitives (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
     System.Json (4.7.1)
@@ -488,7 +524,7 @@ NUGET
       System.Reflection.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
-    System.Memory (4.5.5) - restriction: || (>= net461) (&& (>= net6.0) (< netstandard2.1)) (&& (< net6.0) (>= netcoreapp3.1)) (>= netstandard2.0)
+    System.Memory (4.5.5) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net461) (&& (>= net462) (>= net6.0)) (&& (>= net462) (>= net6.0-windows7.0)) (&& (>= net6.0) (< netstandard2.1)) (&& (< net6.0) (>= net6.0-windows7.0)) (&& (< net6.0) (>= netcoreapp3.1)) (>= netstandard2.0)
       System.Buffers (>= 4.5.1) - restriction: || (&& (>= monoandroid) (< netstandard1.1)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= portable-net45+win8+wpa81) (< win8)) (>= monotouch) (&& (>= net45) (< netstandard2.0)) (&& (< net45) (< netcoreapp2.0) (>= netstandard2.0)) (>= net461) (&& (< netstandard1.1) (>= win8)) (&& (< netstandard2.0) (< uap10.1) (>= wpa81)) (>= xamarinios) (>= xamarinmac) (>= xamarintvos) (>= xamarinwatchos)
       System.Numerics.Vectors (>= 4.4) - restriction: && (< net45) (< netcoreapp2.0) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Numerics.Vectors (>= 4.5) - restriction: >= net461
@@ -496,7 +532,7 @@ NUGET
     System.Memory.Data (6.0) - restriction: >= netstandard2.0
       System.Memory (>= 4.5.4) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
       System.Text.Json (>= 6.0) - restriction: || (>= net461) (>= netstandard2.0)
-    System.Net.Http (4.3.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (>= net461) (>= netstandard2.0)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
+    System.Net.Http (4.3.4) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (>= net461) (< net472) (>= netstandard2.0)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       System.Security.Cryptography.X509Certificates (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net46)
     System.Net.Primitives (4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard2.0) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard2.0) (< win8)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (>= netstandard1.0) (< netstandard1.1) (< win8) (< wp8))
@@ -599,7 +635,7 @@ NUGET
     System.Runtime (4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.2) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.4) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.5) (< win8)) (&& (< monoandroid) (< netstandard1.1) (>= netstandard1.6) (< win8)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (>= netstandard1.1) (< portable-net45+win8+wpa81)) (&& (< netstandard1.1) (>= uap10.0) (< win8)) (&& (>= netstandard1.3) (< portable-net45+win8+wpa81)) (&& (< netstandard1.3) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81)) (>= netstandard2.0)
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.2) (< win8) (< wp8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Runtime.CompilerServices.Unsafe (6.0) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (>= net461) (>= netstandard2.0)
+    System.Runtime.CompilerServices.Unsafe (6.0) - restriction: || (&& (< monoandroid) (>= netcoreapp2.0) (< netcoreapp2.1)) (&& (< monoandroid9.0) (>= net6.0) (< net7.0) (< xamarinios)) (>= net461) (&& (>= net462) (>= net6.0)) (>= netstandard2.0)
     System.Runtime.Extensions (4.3.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.6) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard2.0) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net46) (< netstandard1.6) (>= netstandard2.0)) (&& (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81)) (&& (>= netstandard1.6) (< portable-net45+win8+wpa81))
       Microsoft.NETCore.Platforms (>= 1.1.1) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Targets (>= 1.1.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
@@ -615,7 +651,8 @@ NUGET
       System.Reflection.Primitives (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (>= net462) (&& (>= netcoreapp1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       System.Runtime.Handles (>= 4.3) - restriction: || (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monotouch) (< net45) (< netcoreapp1.1) (>= netstandard1.5) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netcoreapp1.1) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
-    System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (>= net461) (>= netstandard2.0)) (>= uap10.0)
+    System.Runtime.InteropServices.NFloat.Internal (6.0.1) - restriction: >= net6.0-ios
+    System.Runtime.InteropServices.RuntimeInformation (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (>= net461) (< net472) (>= netstandard2.0)) (>= uap10.0)
     System.Runtime.Loader (4.3) - restriction: >= netstandard2.0
       System.IO (>= 4.3) - restriction: && (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Reflection (>= 4.3) - restriction: && (< monotouch) (< net462) (>= netstandard1.5) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -625,7 +662,9 @@ NUGET
       System.Resources.ResourceManager (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Runtime (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.3) (< win8) (< wpa81))
       System.Runtime.Extensions (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.AccessControl (6.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
+    System.Runtime.Serialization.Formatters (4.3) - restriction: && (< net6.0) (>= xamarinios)
+    System.Runtime.Serialization.Primitives (4.3) - restriction: && (< net6.0) (>= xamarinios)
+    System.Security.AccessControl (6.0) - restriction: || (&& (>= monoandroid) (< netstandard1.3) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< net472) (>= netstandard2.0)) (>= netcoreapp2.1) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
       System.Security.Principal.Windows (>= 5.0) - restriction: || (>= net461) (&& (< net6.0) (>= netstandard2.0))
     System.Security.Claims (4.3) - restriction: >= netstandard2.0
       System.Collections (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -696,9 +735,9 @@ NUGET
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading.Tasks (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net46) (>= netstandard1.3) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Cryptography.ProtectedData (6.0) - restriction: || (&& (< net461) (>= netstandard2.0)) (>= net6.0)
+    System.Security.Cryptography.ProtectedData (6.0) - restriction: >= netstandard2.0
       System.Memory (>= 4.5.4) - restriction: && (< net461) (< net6.0) (>= netstandard2.0)
-    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (>= net46) (>= netstandard2.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81)) (&& (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
+    System.Security.Cryptography.X509Certificates (4.3.2) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< netstandard1.6) (>= netstandard2.0)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net45) (>= net461) (>= netstandard2.0)) (&& (>= net46) (>= netstandard2.0)) (&& (>= net461) (< net472) (>= netstandard2.0)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81)) (&& (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       runtime.native.System.Net.Http (>= 4.3) - restriction: && (< monotouch) (< net46) (>= netstandard1.6) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
@@ -733,7 +772,8 @@ NUGET
       System.Windows.Extensions (>= 6.0) - restriction: >= netcoreapp3.1
     System.Security.Principal (4.3) - restriction: >= netstandard2.0
       System.Runtime (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.0) (< win8) (< wp8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
-    System.Security.Principal.Windows (5.0) - restriction: || (&& (< net472) (>= netstandard2.0)) (>= net6.0)
+    System.Security.Principal.Windows (5.0) - restriction: || (&& (>= monoandroid) (< netstandard1.3) (>= netstandard2.0)) (&& (< monoandroid) (>= netcoreapp2.0)) (&& (>= monotouch) (>= netstandard2.0)) (&& (< net46) (< netcoreapp2.0) (>= netstandard2.0)) (&& (>= net461) (>= net6.0)) (&& (>= net461) (>= netstandard2.0)) (&& (< net472) (< net6.0) (>= netstandard2.0)) (>= netcoreapp2.1) (&& (>= netstandard2.0) (>= uap10.1)) (&& (>= netstandard2.0) (>= xamarintvos)) (&& (>= netstandard2.0) (>= xamarinwatchos)) (>= xamarinios) (>= xamarinmac)
+    System.Security.SecureString (4.3) - restriction: || (&& (>= monoandroid10.0) (< net6.0)) (&& (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)) (&& (< net6.0) (>= xamarinios)) (>= net6.0-android) (>= net6.0-ios)
     System.Text.Encoding (4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.6) (< netstandard2.0) (< win8) (< wpa81) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.1) (< netstandard1.2) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.2) (< netstandard1.3) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.2) (>= netstandard1.3) (< win8)) (&& (< monoandroid) (< net45) (>= netstandard1.3) (< netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.4) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.3) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.4) (< netstandard1.5) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.4) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (>= netstandard1.5) (< netstandard1.6) (< win8) (< wpa81)) (&& (< monoandroid) (< net45) (< netstandard1.5) (>= netstandard1.6) (< win8) (< wpa81)) (&& (< net45) (>= net46) (< netstandard1.3)) (&& (< net45) (>= net46) (< netstandard1.4)) (&& (< net46) (>= netstandard2.0) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (>= netstandard1.0) (< portable-net45+win8+wpa81) (< wp8)) (&& (< netstandard1.3) (>= uap10.0) (< win8) (< wpa81)) (&& (< netstandard1.5) (>= uap10.0) (< win8) (< wpa81))
       Microsoft.NETCore.Platforms (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
       Microsoft.NETCore.Targets (>= 1.1) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
@@ -825,6 +865,192 @@ NUGET
       System.Text.Encoding (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Threading (>= 4.3) - restriction: && (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)
       System.Xml.ReaderWriter (>= 4.3) - restriction: || (&& (< monoandroid) (< monotouch) (< net45) (>= netstandard1.3) (< win8) (< wpa81) (< xamarinios) (< xamarinmac) (< xamarintvos) (< xamarinwatchos)) (&& (< monoandroid) (< net45) (>= netstandard1.0) (< netstandard1.3) (< win8) (< wp8) (< wpa81))
+    System.Xml.XmlDocument (4.3) - restriction: && (< net6.0) (>= xamarinios)
+    Xamarin.Android.Arch.Core.Common (1.1.1.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid8.0
+    Xamarin.Android.Arch.Core.Runtime (1.1.1.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Arch.Core.Common (1.1.1.3) - restriction: >= monoandroid8.1
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid8.1
+    Xamarin.Android.Arch.Lifecycle.Common (1.1.1.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid8.0
+    Xamarin.Android.Arch.Lifecycle.LiveData (1.1.1.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Arch.Core.Common (1.1.1.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Arch.Core.Runtime (1.1.1.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Arch.Lifecycle.LiveData.Core (1.1.1.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Arch.Lifecycle.LiveData.Core (1.1.1.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Arch.Core.Common (1.1.1.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Arch.Core.Runtime (1.1.1.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Arch.Lifecycle.Common (1.1.1.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Arch.Lifecycle.Runtime (1.1.1.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Arch.Core.Common (1.1.1.3) - restriction: >= monoandroid8.0
+      Xamarin.Android.Arch.Lifecycle.Common (1.1.1.3) - restriction: >= monoandroid8.0
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid8.0
+    Xamarin.Android.Arch.Lifecycle.ViewModel (1.1.1.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+    Xamarin.Android.Support.AsyncLayoutInflater (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.Collections (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.Compat (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Arch.Lifecycle.Runtime (1.1.1.3) - restriction: >= monoandroid8.0
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid7.1
+      Xamarin.Android.Support.Collections (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.VersionedParcelable (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.CoordinaterLayout (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.CustomView (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.Core.UI (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.AsyncLayoutInflater (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid7.0
+      Xamarin.Android.Support.CoordinaterLayout (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Core.Utils (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.CursorAdapter (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.CustomView (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.DrawerLayout (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Interpolator (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.SlidingPaneLayout (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.SwipeRefreshLayout (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.ViewPager (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.Core.Utils (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid7.0
+      Xamarin.Android.Support.DocumentFile (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Loader (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.LocalBroadcastManager (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Print (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.CursorAdapter (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.CustomTabs (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Collections (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid7.0
+      Xamarin.Android.Support.Core.UI (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Interpolator (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.CustomView (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.DocumentFile (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.DrawerLayout (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.CustomView (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.Interpolator (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.Loader (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Arch.Lifecycle.LiveData (1.1.1.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Arch.Lifecycle.ViewModel (1.1.1.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.LocalBroadcastManager (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.Print (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.SlidingPaneLayout (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.CustomView (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.SwipeRefreshLayout (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Interpolator (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.VersionedParcelable (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Collections (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.Android.Support.ViewPager (28.0.0.3) - restriction: && (< monoandroid10.0) (>= monoandroid9.0) (< net6.0)
+      Xamarin.Android.Support.Annotations (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.Compat (28.0.0.3) - restriction: >= monoandroid9.0
+      Xamarin.Android.Support.CustomView (28.0.0.3) - restriction: >= monoandroid9.0
+    Xamarin.AndroidX.Annotation (1.7.0.3) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation.Jvm (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Migration (>= 1.0.10) - restriction: && (>= monoandroid12.0) (< net6.0-android) (< net7.0-android)
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Annotation.Experimental (1.3.1.4) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Annotation.Jvm (1.7.0.3) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Arch.Core.Common (2.2.0.6) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Arch.Core.Runtime (2.2.0.6) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Arch.Core.Common (>= 2.2.0.6 < 2.2.1) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Browser (1.7.0.1) - restriction: && (>= monoandroid10.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Collection (>= 1.3.0.2) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Concurrent.Futures (>= 1.1.0.17) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Core (>= 1.12.0.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Interpolator (>= 1.0.0.22) - restriction: >= monoandroid12.0
+      Xamarin.Google.Guava.ListenableFuture (>= 1.0.0.17) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Collection (1.3.0.2) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Collection.Jvm (>= 1.3.0.2) - restriction: >= monoandroid12.0
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Collection.Jvm (1.3.0.2) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation.Jvm (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Concurrent.Futures (1.1.0.17) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.Google.Guava.ListenableFuture (>= 1.0.0.17) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Core (1.12.0.3) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Annotation.Experimental (>= 1.3.1.4) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Collection (>= 1.3.0.2) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Concurrent.Futures (>= 1.1.0.17) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Interpolator (>= 1.0.0.22) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Lifecycle.Runtime (>= 2.6.2.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.VersionedParcelable (>= 1.1.1.22) - restriction: >= monoandroid12.0
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Interpolator (1.0.0.22) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Lifecycle.Common (2.6.2.3) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+      Xamarin.KotlinX.Coroutines.Android (>= 1.7.3.3) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Lifecycle.Runtime (2.6.2.3) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Arch.Core.Common (>= 2.2.0.6) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Arch.Core.Runtime (>= 2.2.0.6) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Lifecycle.Common (>= 2.6.2.3 < 2.6.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.ProfileInstaller.ProfileInstaller (>= 1.3.1.5) - restriction: >= monoandroid12.0
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Migration (1.0.10) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.MultiDex (>= 2.0.1.13)
+    Xamarin.AndroidX.MultiDex (2.0.1.22) - restriction: && (>= monoandroid12.0) (< net6.0)
+    Xamarin.AndroidX.ProfileInstaller.ProfileInstaller (1.3.1.5) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Concurrent.Futures (>= 1.1.0.17) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Startup.StartupRuntime (>= 1.1.1.10) - restriction: >= monoandroid12.0
+      Xamarin.Google.Guava.ListenableFuture (>= 1.0.0.17) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Startup.StartupRuntime (1.1.1.10) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Tracing.Tracing (>= 1.1.0.9) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.Tracing.Tracing (1.1.0.9) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+    Xamarin.AndroidX.VersionedParcelable (1.1.1.22) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.AndroidX.Annotation (>= 1.7.0.3) - restriction: >= monoandroid12.0
+      Xamarin.AndroidX.Collection (>= 1.3.0.2) - restriction: >= monoandroid12.0
+    Xamarin.Google.Guava.ListenableFuture (1.0.0.17) - restriction: && (>= monoandroid12.0) (< net6.0)
+    Xamarin.Jetbrains.Annotations (24.1.0.1) - restriction: && (>= monoandroid12.0) (< net6.0)
+    Xamarin.Kotlin.StdLib (1.9.21.1) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.Jetbrains.Annotations (>= 24.1.0.1) - restriction: >= monoandroid12.0
+    Xamarin.Kotlin.StdLib.Common (1.9.21.1) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+    Xamarin.Kotlin.StdLib.Jdk7 (1.9.21.1) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+    Xamarin.Kotlin.StdLib.Jdk8 (1.9.21.1) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.Kotlin.StdLib (>= 1.9.21.1) - restriction: >= monoandroid12.0
+      Xamarin.Kotlin.StdLib.Jdk7 (>= 1.9.21.1) - restriction: >= monoandroid12.0
+    Xamarin.KotlinX.Coroutines.Android (1.7.3.3) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.Kotlin.StdLib.Jdk8 (>= 1.9.21.1) - restriction: >= monoandroid12.0
+      Xamarin.KotlinX.Coroutines.Core.Jvm (>= 1.7.3.3) - restriction: >= monoandroid12.0
+    Xamarin.KotlinX.Coroutines.Core.Jvm (1.7.3.3) - restriction: && (>= monoandroid12.0) (< net6.0)
+      Xamarin.Jetbrains.Annotations (>= 24.1.0.1) - restriction: >= monoandroid12.0
+      Xamarin.Kotlin.StdLib.Common (>= 1.9.21.1) - restriction: >= monoandroid12.0
+      Xamarin.Kotlin.StdLib.Jdk8 (>= 1.9.21.1) - restriction: >= monoandroid12.0
     YoloDev.Expecto.TestSdk (0.13.3)
       Expecto (>= 9.0 < 10.0) - restriction: >= netcoreapp3.1
       FSharp.Core (>= 4.6.2) - restriction: >= netcoreapp3.1

--- a/src/FSharp.CosmosDb/Cosmos.fs
+++ b/src/FSharp.CosmosDb/Cosmos.fs
@@ -29,6 +29,8 @@ module Cosmos =
     let host endpoint =
         { defaultConnectionOp () with Endpoint = Some endpoint }
 
+    let connectWithIdentity op = { op with FromIdentity = true }
+
     let connectWithOptions options accessKey op =
         { op with
             Options = Some options

--- a/src/FSharp.CosmosDb/Cosmos.fs
+++ b/src/FSharp.CosmosDb/Cosmos.fs
@@ -7,6 +7,7 @@ open System
 module Cosmos =
     let private defaultConnectionOp () =
         { Options = None
+          FromIdentity = false
           FromConnectionString = false
           Endpoint = None
           AccessKey = None

--- a/src/FSharp.CosmosDb/Types.fs
+++ b/src/FSharp.CosmosDb/Types.fs
@@ -2,6 +2,7 @@ namespace FSharp.CosmosDb
 
 open FSharp.CosmosDb
 open Microsoft.Azure.Cosmos
+open Azure.Identity
 open System.Threading
 open System.Threading.Tasks
 open System.Collections.Concurrent

--- a/src/FSharp.CosmosDb/Types.fs
+++ b/src/FSharp.CosmosDb/Types.fs
@@ -44,8 +44,23 @@ module internal Caching =
                 |> tryGetOption connStr
                 |> Option.defaultWith (fun () ->
                     let client = new CosmosClient(host, accessKey, clientOps)
-
                     clientCache.[connStr] <- client
+                    client)
+        }
+
+    let fromIdentity host' =
+        maybe {
+            let! host = host'
+            let credential = DefaultAzureCredential()
+
+            let hash = sprintf "%s:%d" <|| (credential.ToString(), credential.GetHashCode())
+
+            return
+                clientCache
+                |> tryGetOption hash
+                |> Option.defaultWith (fun () ->
+                    let client = new CosmosClient(host, credential)
+                    clientCache.[hash] <- client
                     client)
         }
 

--- a/src/FSharp.CosmosDb/Types.fs
+++ b/src/FSharp.CosmosDb/Types.fs
@@ -50,6 +50,7 @@ module internal Caching =
 
 type ConnectionOperation =
     { Options: CosmosClientOptions option
+      FromIdentity: bool
       FromConnectionString: bool
       Endpoint: string option
       AccessKey: string option

--- a/src/FSharp.CosmosDb/paket.references
+++ b/src/FSharp.CosmosDb/paket.references
@@ -1,3 +1,4 @@
 FSharp.Core
 FSharp.Control.AsyncSeq
 Microsoft.Azure.Cosmos
+Azure.Identity


### PR DESCRIPTION
This is to implement the new feature suggested in Issue https://github.com/aaronpowell/FSharp.CosmosDb/issues/73 - connection via default identity instead of keys.

### ~Disclaimer~
~The addition has not been tested as I am still learning how to locally build and test a Nuget package.  Any **help** will be appreciated. So far, I've only read about Nuget [local feeds](https://learn.microsoft.com/en-us/nuget/hosting-packages/local-feeds) but have no clues on how to compile the whole repo into a `.nupkg` file.~

It is supposed to work as follows
```fsharp
let findUsers() =
    host
    |> Cosmos.host
    |> Cosmos.connectWithIdentity
    |> Cosmos.database "UserDb"
    |> Cosmos.container "UserContainer"
    |> Cosmos.query "SELECT u.FirstName, u.LastName FROM u WHERE u.LastName = @name"
    |> Cosmos.parameters [ "@name", box "Powell" ]
    |> Cosmos.execAsync<User>
```